### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
   # index以外にも除外するアクションがあれば後で追記（意図的にコメントしています）
 
   def index
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/javascript/item_price.js
+++ b/app/javascript/item_price.js
@@ -9,3 +9,5 @@ window.addEventListener('load', () => {
   })
 });
 
+
+

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -29,16 +29,8 @@ class Item < ApplicationRecord
     validates :shipping_day_id
   end
 
-  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "is out of setting range" }
-  
+  validates :price,
+            numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range' }
+
   validates :price, numericality: { with: /^[0-9]+$/ }
 end
-
-
-#   99円以下では登録できないこと
-# ・10,000,000以上では登録できないこと
-
-# ・全角文字では登録できないこと
-# ・半角英数混合では登録できないこと
-# ・半角英語だけでは登録できないこと
-# - 販売価格は半角数字のみ保存可能であること

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,59 +123,60 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @items.each do |item| %>
+        <li class='list'>
+          <%# 商品詳細機能実装時に入力 %>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outを表示しましょう %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outを表示しましょう %>
+
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <%# <% if @items.length == 0 %とも書ける> %>
+      <% if @items == [] %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+          <% end %>
+        </li>
+      <% end %>
+  
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -9,103 +9,102 @@ RSpec.describe Item, type: :model do
     context '商品出品ができる時' do
       it '全て揃っている場合に、商品出品ができること' do
         expect(@item).to be_valid
-      end  
+      end
     end
 
     context '商品出品ができない時' do
-      
       it '商品画像を1枚つけることが必須であること' do
         @item.image = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Image can't be blank")
       end
-  
+
       it '商品名が必須であること' do
         @item.name = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Name can't be blank")
       end
-  
+
       it '商品の説明が必須であること' do
         @item.description = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Description can't be blank")
       end
-  
+
       it 'カテゴリーの情報が必須であること' do
         @item.category_id = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Category can't be blank")
       end
-  
+
       it '商品の状態についての情報が必須であること' do
         @item.condition_id = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Condition can't be blank")
       end
-  
+
       it '配送料の負担についての情報が必須であること' do
         @item.shipping_cost_id = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Shipping cost can't be blank")
       end
-  
+
       it '発送元の地域についての情報が必須であること' do
         @item.shipping_place_id = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Shipping place can't be blank")
       end
-  
+
       it '発送までの日数についての情報が必須であること' do
         @item.shipping_day_id = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Shipping day can't be blank")
       end
-  
+
       it '価格についての情報が必須であること' do
         @item.price = nil
         @item.valid?
         expect(@item.errors.full_messages).to include("Price can't be blank")
       end
-      
+
       it 'categoryについて、ActiveHashの中身が一行目の時は登録できない' do
         @item.category_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
-  
+
       it 'conditionについて、ActiveHashの中身が一行目の時は登録できない' do
         @item.condition_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
-  
+
       it 'shipping_costについて、ActiveHashの中身が一行目の時は登録できない' do
         @item.shipping_cost_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Shipping cost must be other than 1')
       end
-  
+
       it 'shipping_placeについて、ActiveHashの中身が一行目の時は登録できない' do
         @item.shipping_place_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Shipping place must be other than 1')
       end
-  
+
       it 'shipping_dayについて、ActiveHashの中身が一行目の時は登録できない' do
         @item.shipping_day_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include('Shipping day must be other than 1')
       end
-      
+
       it '299円以下では登録できないこと' do
-          @item.price = 299
-          @item.valid?
-          expect(@item.errors.full_messages).to include('Price is out of setting range')
+        @item.price = 299
+        @item.valid?
+        expect(@item.errors.full_messages).to include('Price is out of setting range')
       end
 
       it '10,000,000以上では登録できないこと' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is out of setting range')
       end
@@ -117,13 +116,13 @@ RSpec.describe Item, type: :model do
       end
 
       it '半角英数混合では登録できないこと' do
-        @item.price = "jpy500"
+        @item.price = 'jpy500'
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is not a number')
       end
 
       it '半角英語だけでは登録できないこと' do
-        @item.price = "gohyakuen"
+        @item.price = 'gohyakuen'
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is not a number')
       end


### PR DESCRIPTION
what
商品一覧表示機能の実装
why
保存されている出品アイテムがある/ない場合トップページの表示を変えるため

商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/fc4a9b996b78fd4001a746d809ca28c5
商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/392b015680a662e2972a5c948c70ee26